### PR TITLE
add Terms of Use & Privacy Policy legal pages

### DIFF
--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -2,24 +2,23 @@ import React from "react";
 import { AiOutlineMail } from "react-icons/ai";
 import { BsGithub } from "react-icons/bs";
 import { FaMeetup } from "react-icons/fa";
+import Link from "next/link";
 
 const Footer = () => {
   return (
     <footer className="w-full bg-gradient-to-b from-yellow-300 to-orange-400">
-      <h4 className="text-center xl:text-4xl text-3xl  pt-10 font-thin">Contact us</h4>
+      <h4 className="text-center xl:text-4xl text-2xl  pt-10 font-thin">
+        Contact us
+      </h4>
 
-      <div className="flex flex-row items-center justify-center py-4">
+      <div className="flex flex-row items-center justify-center py-2">
         <AiOutlineMail fontSize="2rem" />
-
-        <h2 className="pl-2 text-md xl:text-xl">
-          Email:
           <span className="text-md xl:text-xl  px-2">
             info@codeforhawaii.org
           </span>{" "}
-        </h2>
       </div>
 
-      <div className="flex items-center justify-center gap-10  px-20 py-4 text-xl text-center">
+      <div className="flex items-center justify-center gap-10  px-20 py-2 text-xl text-center">
         <a
           href="https://github.com/CodeWithAloha"
           target="_blank"
@@ -35,11 +34,15 @@ const Footer = () => {
           <FaMeetup fontSize={46} />
         </a>
       </div>
-      <div className="flex items-center gap-10  justify-center  py-6 text-md xl:text-xl text-center">
+      <div className="flex flex-col items-center gap-2 
+      justify-center text-sm xl:text-xl pt-6  ">
         <p>Privacy Policy</p>
-        <p>Terms of Use</p>
+
+        <Link href="/terms-of-use">
+         Terms of Use
+        </Link>
       </div>
-      <p className="text-md xl:text-xl font-semibold text-center py-6">
+      <p className="text-sm xl:text-xl font-semibold text-center py-4">
         Copyright © Code With Aloha 2023
       </p>
     </footer>

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -13,9 +13,9 @@ const Footer = () => {
 
       <div className="flex flex-row items-center justify-center py-2">
         <AiOutlineMail fontSize="2rem" />
-          <span className="text-md xl:text-xl  px-2">
-            info@codeforhawaii.org
-          </span>{" "}
+        <span className="text-md xl:text-xl  px-2">
+          info@codeforhawaii.org
+        </span>{" "}
       </div>
 
       <div className="flex items-center justify-center gap-10  px-20 py-2 text-xl text-center">
@@ -34,13 +34,13 @@ const Footer = () => {
           <FaMeetup fontSize={46} />
         </a>
       </div>
-      <div className="flex flex-col items-center gap-2 
-      justify-center text-sm xl:text-xl pt-6  ">
-        <p>Privacy Policy</p>
-
-        <Link href="/terms-of-use">
-         Terms of Use
-        </Link>
+      <div
+        className="flex flex-col items-center gap-2 
+      justify-center text-sm xl:text-xl pt-6  "
+      >
+       
+        <Link href="/privacy-policy">Privacy Policy</Link>
+        <Link href="/terms-of-use">Terms of Use</Link>
       </div>
       <p className="text-sm xl:text-xl font-semibold text-center py-4">
         Copyright © Code With Aloha 2023

--- a/src/pages/privacy-policy.js
+++ b/src/pages/privacy-policy.js
@@ -1,0 +1,69 @@
+import Footer from "@/components/Footer";
+import NavBar from "@/components/NavBar";
+import React from "react";
+import Link from "next/link";
+import { IoMdArrowBack } from "react-icons/io";
+import { TextBlock } from "./terms-of-use";
+
+const TermsOfUse = () => {
+  return (
+    <>
+      <section
+        className="h-screen px-6 pb-20 overflow-x-hidden 
+      bg-gradient-to-tr from-cyan-200 to bg-white xl:px-60 "
+      >
+        <NavBar />
+        <h1 className="text-xl font-semibold py-6 text-center mx-auto w-2/3 2xl:text-4xl">
+          {" "}
+          Code with Aloha Privacy Policy
+        </h1>
+        <p className="pt-10 2xl:text-xl">
+          Your privacy is important to us. This Privacy Policy outlines how Code
+          with Aloha collects, uses, and protects any information you provide
+          while using our website.
+        </p>
+
+        <TextBlock
+          title="Information We Collect:"
+          text="We do not collect any personal information from visitors to our website. 
+          We do not use cookies or other tracking technologies to gather any data."
+        />
+        <TextBlock
+          title="Links to External Websites:"
+          text="Our website may contain links to external websites. Please note that 
+          we have no control over the content, privacy policies, or practices of these external sites. 
+          Therefore, we cannot be responsible for the protection and privacy of any information you 
+          provide while visiting such sites. 
+          Please exercise caution and review the privacy policies of any external websites you visit."
+        />
+        <TextBlock
+          title="Changes to This Privacy Policy:"
+          text="We may update this Privacy Policy from time to time. 
+          Any changes will be posted on this page. We recommend checking this page periodically 
+          to ensure you are aware of any updates."
+        />
+
+        <TextBlock
+          title="Contact Us:"
+          text="TIf you have any questions or concerns about our Privacy Policy, 
+          please contact us at info@codeforhawaii.org."
+        />
+
+        <TextBlock title="Last updated: " text="June 2023" />
+
+        <Link
+          href="/"
+          className="text-orange-600 font-satisfy text-lg cursor-pointer hover:text-orange-400"
+        >
+          <div className="flex flex-row gap-2 justify-center items-center py-6 font-semibold xl:py-12">
+            <IoMdArrowBack />
+            <p>Back Home</p>
+          </div>
+        </Link>
+      </section>
+      <Footer />
+    </>
+  );
+};
+
+export default TermsOfUse;

--- a/src/pages/privacy-policy.js
+++ b/src/pages/privacy-policy.js
@@ -5,7 +5,7 @@ import Link from "next/link";
 import { IoMdArrowBack } from "react-icons/io";
 import { TextBlock } from "./terms-of-use";
 
-const TermsOfUse = () => {
+const PrivacyPolicy = () => {
   return (
     <>
       <section
@@ -66,4 +66,4 @@ const TermsOfUse = () => {
   );
 };
 
-export default TermsOfUse;
+export default PrivacyPolicy;

--- a/src/pages/terms-of-use.js
+++ b/src/pages/terms-of-use.js
@@ -1,0 +1,107 @@
+import Footer from '@/components/Footer';
+import NavBar from '@/components/NavBar';
+import React from 'react'
+import Link from "next/link";
+import {IoMdArrowBack} from 'react-icons/io'
+
+export const TextBlock =({title, text}) => {
+  return (
+    <div>
+      <h2 className="text-md font-semibold py-3 2xl:text-2xl">{title}</h2>
+      <p className='2xl:text-xl'>{text}</p>
+    </div>
+  );
+}
+
+const TermsOfUse = () => {
+  return (
+    <>
+      <section
+        className="h-screen px-6 pb-20 overflow-x-hidden 
+      bg-gradient-to-tr from-cyan-200 to bg-white xl:px-60 "
+      >
+        <NavBar />
+        <h1 className="text-xl font-semibold py-6 text-center mx-auto w-2/3 2xl:text-4xl">
+          {" "}
+          Code with Aloha Terms of Use
+        </h1>
+
+        <TextBlock
+          title="1. Acceptance of Terms"
+          text="By using the Website, you acknowledge that you have read, understood,
+          and agree to be bound by these Terms."
+        />
+        <TextBlock
+          title="2. Use of the Website"
+          text="Code with Aloha provides the Website for informational purposes only.
+          You may browse, read, and engage with the content on the Website. 
+          You agree to use the Website in a manner consistent with its purpose,
+          which includes accessing information about the projects, team members,
+          and Meetup meetings organized by Code with Aloha."
+        />
+        <TextBlock
+          title="3. Intellectual Property"
+          text="All content on the Website, including but not limited to text,
+          graphics, logos, button icons, images, audio clips, and software, is
+          the property of Code with Aloha or its content suppliers and is
+          protected by applicable copyright laws. 
+          You may not reproduce, distribute, modify, publicly display, or create
+          derivative works of any portion of the Website without the prior
+          written consent of Code with Aloha."
+        />
+
+        <TextBlock
+          title="4. Third-Party Links"
+          text="The Website may contain links to third-party websites or resources
+          that are not owned or controlled by Code with Aloha. We have no
+          control over, and assume no responsibility for, the content, privacy
+          policies, or practices of any third-party websites or resources.
+          Code with Aloha shall not be liable for any loss or damage caused or
+          alleged to be caused by or in connection with the use of any such
+          content, goods, or services available on or through any third-party
+          websites or resources."
+        />
+
+        <TextBlock
+          title="5. Disclaimer of Warranties"
+          text='The Website is provided on an "as is" and "as available" basis. Code
+          with Aloha makes no warranties or representations of any kind, express
+          or implied, regarding the Website, its content, or any information
+          obtained through the Website.
+          Code with Aloha does not warrant that the Website will be error-free,
+          uninterrupted, or free from viruses or other harmful components. You
+          agree that your use of the Website is at your own risk.'
+        />
+        <TextBlock
+          title="6. Limitation of Liability"
+          text="To the fullest extent permitted by applicable law, Code with Aloha
+          shall not be liable for any indirect, incidental, special,
+          consequential, or punitive damages, or any loss of profits or
+          revenues, whether incurred directly or indirectly, or any loss of
+          data, use, goodwill, or other intangible losses, resulting from your
+          access to or use of the Website."
+        />
+        <TextBlock
+          title="7. Governing Law and Jurisdiction"
+          text="These Terms shall be governed by and construed in accordance with the
+          laws of Hawaii. Any disputes arising out of or in connection with
+          these Terms shall be subject to the exclusive jurisdiction of the
+          courts of Hawaii."
+        />
+
+        <Link
+          href="/"
+          className="text-orange-600 font-satisfy text-lg cursor-pointer hover:text-orange-400"
+        >
+          <div className='flex flex-row gap-2 justify-center items-center py-6 font-semibold xl:py-12'>
+            <IoMdArrowBack /> 
+            <p>Back Home</p>
+          </div>
+        </Link>
+      </section>
+      <Footer />
+    </>
+  );
+}
+
+export default TermsOfUse


### PR DESCRIPTION
Added two pages: terms-of-use & privacy-policy, with the necessary content, and a Back Home button.

The links for these pages are located in the footer.

These two pages were not present on the former (currently active) website, so I did some research and put this together. 
As I am not a legal expert, the content might need to be reviewed and customized if we have specific requirements and it is always recommended to seek legal advice to ensure compliance with the laws applicable to HI jurisdiction. But till then, I think that these policies cover us. 

The pages look like this:

![Screenshot 2023-06-07 113432](https://github.com/CodeWithAloha/CWAWebsite/assets/113944962/e7885b05-0003-434e-956b-ccd4a3b7cdbd)

![Screenshot 2023-06-07 122118](https://github.com/CodeWithAloha/CWAWebsite/assets/113944962/24fab909-5441-466c-94fb-3bcfc948667b)

and they are responsive.

Also, made mirror modifications to the Footer component, just style-related. 


