### PR TITLE
Fix Safari logo

### DIFF
--- a/src/components/Logo.js
+++ b/src/components/Logo.js
@@ -10,7 +10,7 @@ const Logo = () => {
       <Link href="/" whileHover={{ scale: 1.5 }}>
         <img
           src="../logo.png"
-          className="w-full xl:max-h-24 max-h-[3rem] cursor-pointer m-2 hover:animate-pulse "
+          className="xl:max-h-24 max-h-[3rem] cursor-pointer m-2 hover:animate-pulse"
         ></img>
       </Link>
     


### PR DESCRIPTION
Fix Safari logo

Seeing a weird bug where the logo is wide mode 😆 

## Before

![Screenshot 2023-09-04 at 7 41 09 PM](https://github.com/CodeWithAloha/CWAWebsite/assets/13753033/5e8d2a93-33a9-4819-b33f-df8b2b3cdda7)

## After

### Safari

![Screenshot 2023-09-04 at 7 42 09 PM](https://github.com/CodeWithAloha/CWAWebsite/assets/13753033/a5debd08-30ba-4c0f-9294-404484c509b6)

### Chrome

![Screenshot 2023-09-04 at 7 42 12 PM](https://github.com/CodeWithAloha/CWAWebsite/assets/13753033/8db6bb38-fa20-41e9-afec-bedc2a1bc183)

### Firefox

![Screenshot 2023-09-04 at 7 42 14 PM](https://github.com/CodeWithAloha/CWAWebsite/assets/13753033/ca984f9d-8d14-45f6-9f21-f2875deeae97)
