### PR TITLE
Comment out configure-pages

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -53,14 +53,14 @@ jobs:
         with:
           node-version: "16"
           cache: ${{ steps.detect-package-manager.outputs.manager }}
-      - name: Setup Pages
-        uses: actions/configure-pages@v3
-        with:
-          # Automatically inject basePath in your Next.js configuration file and disable
-          # server side image optimization (https://nextjs.org/docs/api-reference/next/image#unoptimized).
-          #
-          # You may remove this line if you want to manage the configuration yourself.
-          static_site_generator: next
+      # - name: Setup Pages
+      #   uses: actions/configure-pages@v3
+      #   with:
+      #     # Automatically inject basePath in your Next.js configuration file and disable
+      #     # server side image optimization (https://nextjs.org/docs/api-reference/next/image#unoptimized).
+      #     #
+      #     # You may remove this line if you want to manage the configuration yourself.
+      #     static_site_generator: next
       - name: Restore cache
         uses: actions/cache@v3
         with:
@@ -75,7 +75,7 @@ jobs:
         run: ${{ steps.detect-package-manager.outputs.manager }} ${{ steps.detect-package-manager.outputs.command }}
       - name: Build with Next.js
         run: ${{ steps.detect-package-manager.outputs.runner }} next build
-      - name: Static HTML export with Next.js
+      - name: Static HTML export with Next.js 
         run: ${{ steps.detect-package-manager.outputs.runner }} next export
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v2

--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -75,7 +75,7 @@ jobs:
         run: ${{ steps.detect-package-manager.outputs.manager }} ${{ steps.detect-package-manager.outputs.command }}
       - name: Build with Next.js
         run: ${{ steps.detect-package-manager.outputs.runner }} next build
-      - name: Static HTML export with Next.js 
+      - name: Static HTML export with Next.js
         run: ${{ steps.detect-package-manager.outputs.runner }} next export
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v2


### PR DESCRIPTION
<!--
NOTE: The comments enclosed in these brackets are guides and will not be visible in your pull request description. Please make sure to fill out all the sections as necessary and remove the comments before submitting your PR.
Please provide a brief description of the changes made in this PR for the "Code with Aloha Website".
-->

# Summary

We're facing an issue where the Github pages deployed website is using the wrong URL for assets. For example,

```
https://codewithaloha.org/CWAWebsite/_next/static/css/6087ebff33816151.css
```

It 404s on this URL. Originally, we thought that maybe it was not deploying the build assets, but what was really happening was that the URL itself was incorrect. We found that if we removed `CWAWebsite` from the URL, the asset was there.

```
https://codewithaloha.org/_next/static/css/6087ebff33816151.css
```

<!--
Describe your changes
-->

## Changes

<!-- Please mark the line that applies with an x: [x] -->

- [ ] **Updated Section:** <!--(please specify which section) -->
- [ ] **Added new feature:** <!-- (please describe) -->
- [ ] **Fixed a bug:** <!-- (please describe) -->
- [ ] **Updated documentation**

### Related Issue

<!--Please link to any related issue or provide context for the changes. -->

### Screenshots

<!-- If your changes affect the UI or layout, please attach before-and-after screenshots. -->

<!-- ## Notes -->

<!-- Any additional information or context about the changes.

Thank you for contributing to the Code with Aloha Website! We appreciate your effort and dedication to improving the community through technology.

Commit and push the changes -->
