### PR TITLE
Fix MeetUp link padding

### DIFF
--- a/src/components/Team.js
+++ b/src/components/Team.js
@@ -85,10 +85,10 @@ const Team = () => {
         Be part of our story
       </h4>
       <p className="text-sm xl:text-xl py-4 lg:px-12 text-center  xl:w-1/2">
-        You can join any
+        You can join any{" "}
         <a
           href="#join"
-          className="text-orange-500 hover:text-cyan-400 hover:underline underline-offset-4 px-2"
+          className="text-orange-500 hover:text-cyan-400 hover:underline underline-offset-4"
         >
           MeetUp
         </a>{" "}


### PR DESCRIPTION
<!--
NOTE: The comments enclosed in these brackets are guides and will not be visible in your pull request description. Please make sure to fill out all the sections as necessary and remove the comments before submitting your PR.
Please provide a brief description of the changes made in this PR for the "Code with Aloha Website".
-->

# Summary

<!--
Describe your changes
-->

Fix MeetUp link padding

The "MeetUp" link used padding to simulate a space character on both sides in the sentence. It's more correct (both for accessibility and visual consistency) to use an actual space character and not use any padding.

## Changes

<!-- Please mark the line that applies with an x: [x] -->

- [ ] **Updated Section:** <!--(please specify which section) -->
- [ ] **Added new feature:** <!-- (please describe) -->
- [x] **Fixed a bug:** <!-- (please describe) -->
- [ ] **Updated documentation**

### Related Issue

<!--Please link to any related issue or provide context for the changes. -->

### Screenshots

<!-- If your changes affect the UI or layout, please attach before-and-after screenshots. -->

#### Before

<img width="1440" alt="Screenshot 2024-07-01 at 7 14 30 PM" src="https://github.com/CodeWithAloha/website/assets/13753033/2bda7276-5eed-403e-a0c5-393fb079c257">

#### After

<img width="1440" alt="Screenshot 2024-07-01 at 7 15 04 PM" src="https://github.com/CodeWithAloha/website/assets/13753033/5d766b07-f9da-4f0b-ba4e-aa27dbf32822">


<!-- ## Notes -->

<!-- Any additional information or context about the changes.

Thank you for contributing to the Code with Aloha Website! We appreciate your effort and dedication to improving the community through technology.

Commit and push the changes -->
